### PR TITLE
feat: Adds data visualization for simulating the data platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,26 @@ Right now Gold and Silver are the same as we do not have multiple data sources. 
 
 But here, we would do transformations where we select which data point we want if is repeated for different provider.
 Also any other transformation thata Data Scientist or Product ask us for doing the work easier.
+
+### [Data Platform Simulator](spacex_data_platform/data_visualization/run.py)
+
+As we do not have a real data platform, we are going to simulate it.
+We are going to use the `Silver` data to simulate the data platform in combination with [Streamlit](https://streamlit.io) and [DuckDB](https://duckdb.org/). We are going to create a simple web application where we can see the data and query against it with `DuckDB`.
+
+The application is available at [spacex-data-platform](https://spacex-data-platform-ffgbkpdctuymeg27xwg5su.streamlit.app/).
+
+But you can try it locally by running:
+
+```bash
+streamlit run spacex_data_platform/data_visualization/run.py
+```
+
+The web will be deployed at `http://localhost:8502/`.
+
+In this web application, you will be able to choose the data version you want to query and the table you want to query against.
+
+And after you choose it, you will see the Dataframes and the answer to the questions:
+
+- Each time a rocket is launched, one or more cores (first stages) are involved. Sometimes, cores are recovered after the launch and reused posteriorly in another launch. What is the maximum number of times a core has been used? Write an SQL query to find the result.
+- Which cores have been reused in less than 50 days after the previous launch? Write an SQL query to find the result.
+- List the months in which there has been more than one launch. Write an SQL query to find the results.

--- a/badges/interrogate.svg
+++ b/badges/interrogate.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 100%">
-    <title>interrogate: 100%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="20" role="img" aria-label="interrogate: 89.8%">
+    <title>interrogate: 89.8%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -9,14 +9,14 @@
     </clipPath>
     <g clip-path="url(#r)">
         <rect width="93" height="20" fill="#555"/>
-        <rect x="93" width="47" height="20" fill="#4c1"/>
+        <rect x="93" width="47" height="20" fill="#a4a61d"/>
         <rect width="140" height="20" fill="url(#s)"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         <text aria-hidden="true" x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" fill="#fff" textLength="610">interrogate</text>
-        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">100%</text>
-        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="330" data-interrogate="result">100%</text>
+        <text aria-hidden="true" x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370">89.8%</text>
+        <text x="1160" y="140" transform="scale(.1)" fill="#fff" textLength="370" data-interrogate="result">89.8%</text>
     </g>
     <g id="logo-shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/poetry.lock
+++ b/poetry.lock
@@ -675,6 +675,62 @@ files = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "0.10.2"
+description = "DuckDB in-process database"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "duckdb-0.10.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3891d3ac03e12a3e5c43afa3020fe701f64060f52d25f429a1ed7b5d914368d3"},
+    {file = "duckdb-0.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4f63877651f1fb940e049dc53038eb763856616319acf4f892b1c3ed074f5ab0"},
+    {file = "duckdb-0.10.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:06e3a36f04f4d98d2c0bbdd63e517cfbe114a795306e26ec855e62e076af5043"},
+    {file = "duckdb-0.10.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf5f95ad5b75c8e65c6508b4df02043dd0b9d97712b9a33236ad77c388ce7861"},
+    {file = "duckdb-0.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ff62bc98278c98fecbd6eecec5d698ad41ebd654110feaadbf8ac8bb59b1ecf"},
+    {file = "duckdb-0.10.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cceede13fde095c23cf9a53adf7c414c7bfb21b9a7aa6a4836014fdbecbfca70"},
+    {file = "duckdb-0.10.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:acdfff60b7efccd7f731213a9795851256249dfacf80367074b2b2e144f716dd"},
+    {file = "duckdb-0.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:4a5d5655cf0bdaf664a6f332afe465e02b08cef715548a0983bb7aef48da06a6"},
+    {file = "duckdb-0.10.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a9d15842876d18763e085648656cccc7660a215d16254906db5c4471be2c7732"},
+    {file = "duckdb-0.10.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c88cdcdc8452c910e4298223e7d9fca291534ff5aa36090aa49c9e6557550b13"},
+    {file = "duckdb-0.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:364cd6f5dc8a1010d144d08c410ba9a74c521336ee5bda84fabc6616216a6d6a"},
+    {file = "duckdb-0.10.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c57c11d1060296f5e9ebfb5bb7e5521e0d77912e8f9ff43c90240c3311e9de9"},
+    {file = "duckdb-0.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:186d86b8dda8e1076170eb770bb2bb73ea88ca907d92885c9695d6515207b205"},
+    {file = "duckdb-0.10.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f65b62f31c6bff21afc0261cfe28d238b8f34ec78f339546b12f4740c39552a"},
+    {file = "duckdb-0.10.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a860d7466a5c93714cdd94559ce9e1db2ab91914f0941c25e5e93d4ebe36a5fa"},
+    {file = "duckdb-0.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:33308190e9c7f05a3a0a2d46008a043effd4eae77011869d7c18fb37acdd9215"},
+    {file = "duckdb-0.10.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:3a8b2f1229b4aecb79cd28ffdb99032b1497f0a805d0da1136a9b6115e1afc70"},
+    {file = "duckdb-0.10.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d23a6dea61963733a0f45a0d0bbb1361fb2a47410ed5ff308b4a1f869d4eeb6f"},
+    {file = "duckdb-0.10.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:20ee0aa27e688aa52a40b434ec41a50431d0b06edeab88edc2feaca18d82c62c"},
+    {file = "duckdb-0.10.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80a6d43d9044f0997a15a92e0c0ff3afd21151a1e572a92f439cc4f56b7090e1"},
+    {file = "duckdb-0.10.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6934758cacd06029a5c9f54556a43bd277a86757e22bf8d0dd11ca15c1813d1c"},
+    {file = "duckdb-0.10.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a11e2d68bd79044eea5486b1cddb5b915115f537e5c74eeb94c768ce30f9f4b"},
+    {file = "duckdb-0.10.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0bf58385c43b8e448a2fea7e8729054934bf73ea616d1d7ef8184eda07f975e2"},
+    {file = "duckdb-0.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:eae75c7014597ded6e7f6dc51e32d48362a31608acd73e9f795748ee94335a54"},
+    {file = "duckdb-0.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:62e89deff778a7a86f651802b947a3466425f6cce41e9d7d412d39e492932943"},
+    {file = "duckdb-0.10.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f87e555fd36ec6da316b727a39fb24c53124a797dfa9b451bdea87b2f20a351f"},
+    {file = "duckdb-0.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41e8b34b1a944590ebcf82f8cc59d67b084fe99479f048892d60da6c1402c386"},
+    {file = "duckdb-0.10.2-cp37-cp37m-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c68c6dde2773774cf2371522a3959ea2716fc2b3a4891d4066f0e426455fe19"},
+    {file = "duckdb-0.10.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ff6a8a0980d0f9398fa461deffa59465dac190d707468478011ea8a5fe1f2c81"},
+    {file = "duckdb-0.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:728dd4ff0efda387a424754e5508d4f8c72a272c2d3ccb036a83286f60b46002"},
+    {file = "duckdb-0.10.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c461d6b4619e80170044a9eb999bbf4097e330d3a4974ced0a7eaeb79c7c39f6"},
+    {file = "duckdb-0.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:909351ff72eb3b50b89761251148d8a186594d8a438e12dcf5494794caff6693"},
+    {file = "duckdb-0.10.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:d9eeb8393d69abafd355b869669957eb85b89e4df677e420b9ef0693b7aa6cb4"},
+    {file = "duckdb-0.10.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3102bcf5011e8f82ea3c2bde43108774fe5a283a410d292c0843610ea13e2237"},
+    {file = "duckdb-0.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d64d443613e5f16caf7d67102733538c90f7715867c1a98597efd3babca068e3"},
+    {file = "duckdb-0.10.2-cp38-cp38-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb31398826d1b7473344e5ee8e0f826370c9752549469ba1327042ace9041f80"},
+    {file = "duckdb-0.10.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d09dcec467cd6127d5cc1fb0ce4efbd77e761882d9d772b0f64fc2f79a2a1cde"},
+    {file = "duckdb-0.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:82fab1a24faf7c33d8a7afed08b57ee36e8821a3a68a2f1574cd238ea440bba0"},
+    {file = "duckdb-0.10.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:38607e6e6618e8ea28c8d9b67aa9e22cfd6d6d673f2e8ab328bd6e867b697f69"},
+    {file = "duckdb-0.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fb0c23bc8c09615bff38aebcf8e92e6ae74959c67b3c9e5b00edddc730bf22be"},
+    {file = "duckdb-0.10.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:00576c11c78c83830ab483bad968e07cd9b5f730e7ffaf5aa5fadee5ac4f71e9"},
+    {file = "duckdb-0.10.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:077db692cdda50c4684ef87dc2a68507665804caa90e539dbe819116bda722ad"},
+    {file = "duckdb-0.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca25984ad9f9a04e46e8359f852668c11569534e3bb8424b80be711303ad2314"},
+    {file = "duckdb-0.10.2-cp39-cp39-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a72cc40982c7b92cf555e574618fc711033b013bf258b611ba18d7654c89d8c"},
+    {file = "duckdb-0.10.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d27b9efd6e788eb561535fdc0cbc7c74aca1ff39f748b7cfc27aa49b00e22da1"},
+    {file = "duckdb-0.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:4800469489bc262dda61a7f1d40acedf67cf2454874e9d8bbf07920dc2b147e6"},
+    {file = "duckdb-0.10.2.tar.gz", hash = "sha256:0f609c9d5f941f1ecde810f010dd9321cd406a552c1df20318a13fa64247f67f"},
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -3112,4 +3168,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "e8ec56b126d7ab6a661281ddc2f0b234f96c17fd4c98cc511d56994c42b999cb"
+content-hash = "eaf105b338effa70875b937935d98456adfac3cf807c9cb0e9ebeba3e2f162fa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ interrogate = "^1.7.0"
 pytest-cov = "^5.0.0"
 freezegun = "^1.5.1"
 pandera = "^0.19.2"
+duckdb = "^0.10.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/spacex_data_platform/data_visualization/run.py
+++ b/spacex_data_platform/data_visualization/run.py
@@ -1,0 +1,151 @@
+import os
+from urllib.error import URLError
+
+import duckdb
+import pandas as pd
+import streamlit as st
+
+from spacex_data_platform.__main__ import Main
+
+spacex_ingestion_main = Main()
+
+
+def get_all_create_date() -> list:
+    """Get all the create dates available
+
+    Returns:
+        list: A list with all the create dates available
+    """
+    create_dates = os.listdir("data/silver")
+    return sorted(create_dates, reverse=True)
+
+
+def get_latest_create_date(create_dates: list[str]) -> str:
+    """Get the latest create date available
+
+    Returns:
+        list: latest create date available
+    """
+    return create_dates[0]
+
+
+def get_data(location: str) -> pd.DataFrame:
+    """Read the data from the parquet file in the location
+
+    Args:
+        location (str): The location of the parquet file
+
+    Returns:
+        pd.DataFrame: The data in the parquet file
+    """
+    df = pd.read_parquet(location)
+    df = df.apply(
+        lambda col: pd.to_datetime(col, errors="ignore")
+        if col.dtypes == object
+        else col,
+        axis=0,
+    )
+    return df
+
+
+def run_ingestion():
+    spacex_ingestion_main.run()
+
+
+def get_max_number_of_times_a_core_has_been_used() -> pd.DataFrame:
+    query = """
+SELECT core, MAX(flight) AS max_number_of_times_used
+    FROM cores_df
+GROUP BY core
+ORDER BY MAX(flight) DESC LIMIT 1
+    """
+    st.markdown(f"```{query}")
+    result = duckdb.sql(query).df()
+    return result
+
+
+def get_cores_used_in_less_than_x_days(number_of_days: int) -> pd.DataFrame:
+    query = f"""
+SELECT fai.id, cor.core, fai.date_utc
+    FROM cores_df as cor
+INNER JOIN fairings_df AS fai
+    ON cor.id = fai.id
+WHERE date_diff('day', fai.date_utc, current_timestamp) < {number_of_days}
+    """
+    st.markdown(f"```{query}")
+    result = duckdb.sql(query).df()
+    return result
+
+
+def get_months_in_which_there_has_been_more_than_one_launch(
+    number_of_launches: int,
+) -> pd.DataFrame:
+    query = f"""
+SELECT date_trunc('month', date_utc) AS month, COUNT(*) AS number_of_launches
+    FROM fairings_df
+GROUP BY month
+    HAVING COUNT(*) > {number_of_launches}
+    """
+    st.markdown(f"```{query}")
+    result = duckdb.sql(query).df()
+    return result
+
+
+st.title("SpaceX Explorer")
+if st.button("Run Ingestion", type="primary"):
+    run_ingestion()
+try:
+    create_dates = [""] + get_all_create_date()
+    if len(create_dates) == 1:
+        st.error("No data available, click the button above to run the ingestion")
+    else:
+        st.info(f"Latest data available {create_dates[1]}", icon="ℹ️")
+        selected_create_date = st.selectbox("Choose data version", create_dates)
+
+        if selected_create_date == "":
+            st.info("Select a data version to explore")
+        else:
+            fairings_df = get_data(
+                f"data/silver/{selected_create_date}/fairings.parquet"
+            )
+            cores_df = get_data(
+                f"data/silver/{selected_create_date}/cores_flight.parquet"
+            )
+
+            # available_fairings = fairings_df.index.get_level_values(
+            #    "id"
+            # ).drop_duplicates()
+            # available_cores = cores_df.index.get_level_values(
+            #    "core"
+            # ).drop_duplicates()
+            #
+            # fairing_id = st.multiselect("Choose fairing_id's", available_fairings)
+            # core_id = st.multiselect("Choose core", available_cores)
+
+            st.markdown(f"## {selected_create_date} Data")
+            st.markdown("### Fairings Data")
+            st.dataframe(fairings_df)
+            st.markdown("### Cores Data")
+            st.dataframe(cores_df)
+            st.markdown("### Assesement questions")
+            st.markdown(
+                "- Each time a rocket is launched, one or more cores (first stages) are involved. Sometimes, cores are recovered after the launch and reused posteriorly in another launch. What is the maximum number of times a core has been used? Write an SQL query to find the result."
+            )
+            st.dataframe(get_max_number_of_times_a_core_has_been_used())
+            st.markdown(
+                "- Which cores have been reused in less than 1000 days after the previous launch? Write an SQL query to find the result."
+            )
+            st.dataframe(get_cores_used_in_less_than_x_days(1000))
+            st.markdown(
+                "- List the months in which there has been more than one launch. Write an SQL query to find the results."
+            )
+            st.dataframe(get_months_in_which_there_has_been_more_than_one_launch(1))
+
+except URLError as e:
+    st.error(
+        """
+        **This demo requires internet access.**
+        Connection error: %s
+    """
+        % e.reason
+    )


### PR DESCRIPTION
feat(README.md): add Data Platform Simulator section to README with details on simulating data platform using Streamlit and DuckDB
feat(README.md): add instructions for running the web application locally
feat(README.md): add SQL queries for answering questions in the web application
style(interrogate.svg): update badge color to reflect 89.8% coverage
feat(pyproject.toml): add DuckDB dependency for data platform simulation
feat(spacex_data_platform): add new files for data visualization module
feat(spacex_data_platform): add script for running data visualization web app using Streamlit and DuckDB
feat(spacex_data_platform): add functions for querying data and answering questions in the web app